### PR TITLE
External secrets support and fixes for snapshot helm chart

### DIFF
--- a/snapshot/Chart.yaml
+++ b/snapshot/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/snapshot/Chart.yaml
+++ b/snapshot/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: platerec-helm
+name: platerec-snapshot
 description: Accurate, Fast, Developer-Friendly ANPR
 
 # A chart can be either an 'application' or a 'library' chart.

--- a/snapshot/Chart.yaml
+++ b/snapshot/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: platerec-snapshot
 description: Accurate, Fast, Developer-Friendly ANPR
 

--- a/snapshot/templates/_helpers.tpl
+++ b/snapshot/templates/_helpers.tpl
@@ -101,3 +101,7 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
 {{- define "platerec-snapshot.pvc.claimname" -}}
 {{- .Values.persistence.name -}}
 {{- end -}}
+
+{{- define "platerec-snapshot.secretname" -}}
+{{- .Values.existingSecret | default (printf "%s-auth" (include "platerec-snapshot.fullname" .)) -}}
+{{- end -}}

--- a/snapshot/templates/deployment.yaml
+++ b/snapshot/templates/deployment.yaml
@@ -44,13 +44,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: TOKEN
-                  name: {{ include "platerec-snapshot.fullname" . }}-auth
+                  name: {{ include "platerec-snapshot.secretname" . }}
             - name: "LICENSE_KEY"
               valueFrom:
                 secretKeyRef:
                   key: LICENSE_KEY
-                  name: {{ include "platerec-snapshot.fullname" . }}-auth
-
+                  name: {{ include "platerec-snapshot.secretname" . }}
           ports:
             - name: http
               containerPort: 8080

--- a/snapshot/templates/deployment.yaml
+++ b/snapshot/templates/deployment.yaml
@@ -1,38 +1,38 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "platerec-helm.fullname" . }}
+  name: {{ include "platerec-snapshot.fullname" . }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "platerec-helm.labels" . | nindent 4 }}
+    {{- include "platerec-snapshot.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "platerec-helm.selectorLabels" . | nindent 6 }}
+      {{- include "platerec-snapshot.selectorLabels" . | nindent 6 }}
   {{- if .Values.updateStrategy }}
   strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
-  {{- end }}    
+  {{- end }}
   template:
     metadata:
       labels:
-        {{- include "platerec-helm.selectorLabels" . | nindent 8 }}
+        {{- include "platerec-snapshot.selectorLabels" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      serviceAccountName: {{ include "platerec-helm.serviceAccountName" . }}
+      serviceAccountName: {{ include "platerec-snapshot.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      volumes: 
+      volumes:
         - name: license-data
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ .Values.persistence.existingClaim | default (include "platerec-helm.pvc.claimname" .) }}  
+            claimName: {{ .Values.persistence.existingClaim | default (include "platerec-snapshot.pvc.claimname" .) }}
         {{- else }}
           emptyDir: {}
-        {{- end }}      
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -44,20 +44,20 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: TOKEN
-                  name: {{ include "platerec-helm.fullname" . }}-auth
+                  name: {{ include "platerec-snapshot.fullname" . }}-auth
             - name: "LICENSE_KEY"
               valueFrom:
                 secretKeyRef:
                   key: LICENSE_KEY
-                  name: {{ include "platerec-helm.fullname" . }}-auth      
-                 
+                  name: {{ include "platerec-snapshot.fullname" . }}-auth
+
           ports:
             - name: http
               containerPort: 8080
               protocol: TCP
             - name: http-live
               containerPort: 8081
-              protocol: TCP  
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /liveliness/
@@ -72,12 +72,12 @@ spec:
             timeoutSeconds: 60
           volumeMounts:
             - mountPath: /license
-              name: license-data    
+              name: license-data
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
 
-      
+
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/snapshot/templates/extra.yaml
+++ b/snapshot/templates/extra.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ tpl . $ }}
+{{- end }}

--- a/snapshot/templates/ingress.yaml
+++ b/snapshot/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "platerec-snapshot.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
+apiVersion: networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1

--- a/snapshot/templates/pvc.yaml
+++ b/snapshot/templates/pvc.yaml
@@ -2,11 +2,11 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ include "platerec-helm.pvc.claimname" . }}
+  name: {{ include "platerec-snapshot.pvc.claimname" . }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    app: "{{ include "platerec-helm.fullname" . }}"
-    chart: "{{ template "platerec-helm.chart" . }}"
+    app: "{{ include "platerec-snapshot.fullname" . }}"
+    chart: "{{ template "platerec-snapshot.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
@@ -15,5 +15,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  {{ include "platerec-helm.storageClass" . }}
-{{- end -}}  
+  {{ include "platerec-snapshot.storageClass" . }}
+{{- end -}}

--- a/snapshot/templates/secret.yaml
+++ b/snapshot/templates/secret.yaml
@@ -1,8 +1,10 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "platerec-snapshot.fullname" . }}-auth
+  name: {{ include "platerec-snapshot.secretname" . }}
   namespace: {{ $.Release.Namespace }}
 data:
   TOKEN: {{ .Values.TOKEN | b64enc }}
   LICENSE_KEY: {{ .Values.LICENSE_KEY | b64enc }}
+{{- end }}

--- a/snapshot/templates/secret.yaml
+++ b/snapshot/templates/secret.yaml
@@ -1,9 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "platerec-helm.fullname" . }}-auth
+  name: {{ include "platerec-snapshot.fullname" . }}-auth
   namespace: {{ $.Release.Namespace }}
 data:
   TOKEN: {{ .Values.TOKEN | b64enc }}
   LICENSE_KEY: {{ .Values.LICENSE_KEY | b64enc }}
-  

--- a/snapshot/templates/service.yaml
+++ b/snapshot/templates/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "platerec-helm.fullname" . }}
+  name: {{ include "platerec-snapshot.fullname" . }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "platerec-helm.labels" . | nindent 4 }}
+    {{- include "platerec-snapshot.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
@@ -34,6 +34,6 @@ spec:
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
-      {{- end }}  
+      {{- end }}
   selector:
-    {{- include "platerec-helm.selectorLabels" . | nindent 4 }}
+    {{- include "platerec-snapshot.selectorLabels" . | nindent 4 }}

--- a/snapshot/templates/serviceaccount.yaml
+++ b/snapshot/templates/serviceaccount.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "platerec-helm.serviceAccountName" . }}
+  name: {{ include "platerec-snapshot.serviceAccountName" . }}
   namespace: {{ $.Release.Namespace }}
   labels:
-{{ include "platerec-helm.labels" . | nindent 4 }}
+{{ include "platerec-snapshot.labels" . | nindent 4 }}
 {{- end -}}

--- a/snapshot/values.yaml
+++ b/snapshot/values.yaml
@@ -2,9 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-#PlateRecognizer token and license
+# PlateRecognizer token and license - alternatively you can use `existingSecret`
 TOKEN:
 LICENSE_KEY:
+
+# Alternatively you can provide TOKEN and LICENSE_KEY in an externally provided secret
+# existingSecret: your-secret
 
 replicaCount: 1
 

--- a/snapshot/values.yaml
+++ b/snapshot/values.yaml
@@ -101,3 +101,5 @@ persistence:
   accessMode: ReadWriteOnce
   size: 1Gi
   name: license
+
+extraDeploy: []


### PR DESCRIPTION
Hi,

We're looking into running this in kubernetes and noticed some issues:

1. With the introduction of the stream helm chart, the snapshot helm chart broke due to incorrect includes
2. The helm chart is inconsistently named after the same introduction (should be `platerec-snapshot` in my opinion)
3. No support for Ingress in Kubernetes >1.22
4. No support for external secrets to provide TOKEN and LICENSE_KEY
5. Helm chart doesn't lint as it is `v1` and `type: application` is not supported before `v2`

I addressed both those issues in this PR for your consideration.

Also: How about publishing this helm chart via GitHub? This would make it much more convenient to use.
Instructions for how to easily do this are available e.g. [here](https://faun.pub/how-to-host-helm-chart-repository-on-github-b76c854e1462)